### PR TITLE
update to PK-Sim 10 including OATP1B1 adaptation

### DIFF
--- a/Erythromycin-Model.json
+++ b/Erythromycin-Model.json
@@ -10306,7 +10306,7 @@
             },
             {
               "Name": "kcat",
-              "Value": 2.0201069202,
+              "Value": 1.350032201,
               "Unit": "1/min",
               "ValueOrigin": {
                 "Source": "ParameterIdentification",
@@ -21266,7 +21266,7 @@
             "BackColor": "#FFFFFF",
             "DiagramBackColor": "#FFFFFF"
           },
-          "OriginText": "Erythromycin-Model\nTreatment_Olkkola1993_IV\n2021-09-06 15:25"
+          "OriginText": "Erythromycin_v05_OATP1B1_Test (3)\nTreatment_Olkkola1993_IV\n2020-01-13 16:28"
         }
       ],
       "Interactions": [
@@ -21436,7 +21436,7 @@
             }
           ],
           "Name": "Time Profile Analysis",
-          "OriginText": "Erythromycin-Model\nControl_Olkkola1993_IV\n2021-09-06 15:23"
+          "OriginText": "Erythromycin_v04\nControl_Olkkola1993_IV\n2019-12-03 11:55"
         }
       ]
     },
@@ -22056,7 +22056,7 @@
             }
           ],
           "Name": "Time Profile Analysis",
-          "OriginText": "Erythromycin-Model\nControl_Olkkola1993_PO\n2021-09-06 15:23"
+          "OriginText": "Erythromycin_v04\nControl_Olkkola1993_PO\n2019-12-03 12:00"
         }
       ]
     },
@@ -25006,7 +25006,7 @@
             "BackColor": "#FFFFFF",
             "DiagramBackColor": "#FFFFFF"
           },
-          "OriginText": "Erythromycin-Model\nTreatment_Olkkola1993_Oral\n2021-09-06 15:26"
+          "OriginText": "Erythromycin\nTreatment_Olkkola1993_Oral\n2020-01-14 15:52"
         }
       ],
       "Interactions": [

--- a/Evaluation/Input/Content/Section2.3_Model_Parameters_and_Assumptions.md
+++ b/Evaluation/Input/Content/Section2.3_Model_Parameters_and_Assumptions.md
@@ -56,26 +56,26 @@ To better inform optimization of these two parameters, clinical data of a midazo
 
 This is the result of the final parameter identification:
 
-| Model Parameter                     | Formulation type/salt form               | Optimized Value  | Unit   |
-| ----------------------------------- | ---------------------------------------- | ---------------- | ------ |
-| `Dissolution shape `                | Enteric coated pellets                   | 1.0564916105     |        |
-| `Dissolution shape `                | Enteric coated tablet                    | 1.0838799888     |        |
-| `Dissolution shape `                | Filmcoated tablet (except 250 mg dose)   | 1.0960212213     |        |
-| `Dissolution shape `                | Filmcoated tablet, 250 mg                | 3.2811974117     |        |
-| `Dissolution time (50% dissolved) ` | Enteric coated pellets                   | 1.7462743767     | min    |
-| `Dissolution time (50% dissolved) ` | Enteric coated tablet                    | 79.6337524677    | min    |
-| `Dissolution time (50% dissolved) ` | Filmcoated tablet (except 250 mg dose)   | 1.7038947098     | min    |
-| `Dissolution time (50% dissolved) ` | Filmcoated tablet, 250 mg                | 83.6562552486    | min    |
-| `GFR fraction`                      |                                          | 1.1591081815     |        |
-| `K_kinact_half` (CYP3A4)            |                                          | 7.6007360452     | µmol/L |
-| `kcat` (OATP1B1)                    |                                          | 2.0201069202     | 1/min  |
-| `kinact` (CYP3A4)                   |                                          | 0.0296261146     | 1/min  |
-| `Km` (OATP1B1)                      |                                          | 0.735836485      | µmol/L |
-| `Lag time`                          | Enteric coated pellets                   | 54.3490442506    | min    |
-| `Lag time`                          | Enteric coated tablet                    | 78.7967495765    | min    |
-| `Solubility at ref pH`              | Enteric coated tablet, erythromycin base | 8.3990771997     | mg/L   |
-| `Solubility at ref pH`              | Filmcoated tablet, erythromycin stearate | 28.0708790976    | mg/L   |
-| `Specific clearance`                |                                          | 4.1462183378     | 1/min  |
-| `Specific intestinal permeability`  |                                          | 0.00038668371665 | cm/min |
+| Model Parameter                     | Formulation type/salt form               | Optimized Value          | Unit   |
+| ----------------------------------- | ---------------------------------------- | ------------------------ | ------ |
+| `Dissolution shape `                | Enteric coated pellets                   | 1.0564916105             |        |
+| `Dissolution shape `                | Enteric coated tablet                    | 1.0838799888             |        |
+| `Dissolution shape `                | Filmcoated tablet (except 250 mg dose)   | 1.0960212213             |        |
+| `Dissolution shape `                | Filmcoated tablet, 250 mg                | 3.2811974117             |        |
+| `Dissolution time (50% dissolved) ` | Enteric coated pellets                   | 1.7462743767             | min    |
+| `Dissolution time (50% dissolved) ` | Enteric coated tablet                    | 79.6337524677            | min    |
+| `Dissolution time (50% dissolved) ` | Filmcoated tablet (except 250 mg dose)   | 1.7038947098             | min    |
+| `Dissolution time (50% dissolved) ` | Filmcoated tablet, 250 mg                | 83.6562552486            | min    |
+| `GFR fraction`                      |                                          | 1.1591081815             |        |
+| `K_kinact_half` (CYP3A4)            |                                          | 7.6007360452             | µmol/L |
+| `kcat` (OATP1B1)                    |                                          | 2.0201069202<sup>*</sup> | 1/min  |
+| `kinact` (CYP3A4)                   |                                          | 0.0296261146             | 1/min  |
+| `Km` (OATP1B1)                      |                                          | 0.735836485              | µmol/L |
+| `Lag time`                          | Enteric coated pellets                   | 54.3490442506            | min    |
+| `Lag time`                          | Enteric coated tablet                    | 78.7967495765            | min    |
+| `Solubility at ref pH`              | Enteric coated tablet, erythromycin base | 8.3990771997             | mg/L   |
+| `Solubility at ref pH`              | Filmcoated tablet, erythromycin stearate | 28.0708790976            | mg/L   |
+| `Specific clearance`                |                                          | 4.1462183378             | 1/min  |
+| `Specific intestinal permeability`  |                                          | 0.00038668371665         | cm/min |
 
-<sup>*</sup> The value was set to 1.350032201 /min with the release of PK-Sim 10 to account for the updated calculation method of interstitial concentrations (please refer to the respective [release notes of version 10](https://github.com/Open-Systems-Pharmacology/Suite/releases/tag/v10)).
+<sup>*</sup> The value in the model was updated to 1.350032201 with the release of PK-Sim 10 to account for the updated calculation method of interstitial concentrations (please refer to the respective [release notes of version 10](https://github.com/Open-Systems-Pharmacology/Suite/releases/tag/v10.0)).


### PR DESCRIPTION
- update of ATP1A2 reference concentrations to account for pk-sim 10 update in interstitial concentration calculations
- update of OATP1B1 kcat value to account for pk-sim 10 update in interstitial concentration calculations
- update static content describing consideration of pk-sim 10 update in interstitial concentration calculations

In the previous update commited by @AndreDlm, the OATP1B1 kcat value was not updated.